### PR TITLE
Fix error-checking test on newer distros

### DIFF
--- a/tests/test-prog.c
+++ b/tests/test-prog.c
@@ -307,7 +307,7 @@ int main(int argc, char **argv)
                 goto cleanup;
             }
             errmsg = injector_error();
-            if (strcmp(errmsg, INJECT_ERRMSG) != 0) {
+            if (strncmp(errmsg, INJECT_ERRMSG, strlen(INJECT_ERRMSG)) != 0) {
                 printf("unexpected injection error message: %s\n", errmsg);
                 goto cleanup;
             }


### PR DESCRIPTION
The test which checks for an error message when injecting `Makefile` fails on newer distros because they return the error string `invalid ELF header` which the test does not expect. This patch checks just the start of the error string so that both old and new behavior are passing, while still failing on other unexpected error messages.

Ubuntu 18.04 doesn't have this problem, which is why the CI testing hasn't picked it up yet. 