### PR TITLE
Add support for musl libc

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,3 +46,18 @@ jobs:
       shell: cmd
       run: |
         cd tests && .\test-prog-x64.exe
+
+  tests_on_alpine_x86_64:
+    name: Tests on Alpine (x86_64 and i686)
+    runs-on: ubuntu-latest
+    container: alpine
+    steps:
+    - name: Install packages
+      run: |
+        apk add gcc musl-dev git make
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - name: run tests
+      run: |
+        make check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
         cd tests && .\test-prog-x64.exe
 
   tests_on_alpine_x86_64:
-    name: Tests on Alpine (x86_64 and i686)
+    name: Tests on Alpine (x86_64 only)
     runs-on: ubuntu-latest
     container: alpine
     steps:

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ injector process \ target process | arm64 | armhf | armel
 *1: [x32 ABI](https://en.wikipedia.org/wiki/X32_ABI)  
 *2: failure with `64-bit target process isn't supported by 32-bit process`.  
 *3: failure with `x32-ABI target process is supported only by x86_64`.  
-*4: tested on github actions  
+*4: tested on github actions on both glibc and musl
 
 ## Windows
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ See [`Usage` section and `Sample` section in linux-inject][`inject`] and substit
 
 injector process \ target process | x86_64 | i386 | x32(*1)
 ---|---|---|---
-**x86_64** | success(*4) | success(*4) | success(*4)
+**x86_64** | success(*5) | success(*4) | success(*4)
 **i386**   | failure(*2) | success(*4) | failure(*3)
 **x32**(*1) | failure(*2) | success(*4) | failure(*3)
 
@@ -138,7 +138,9 @@ injector process \ target process | arm64 | armhf | armel
 *1: [x32 ABI](https://en.wikipedia.org/wiki/X32_ABI)  
 *2: failure with `64-bit target process isn't supported by 32-bit process`.  
 *3: failure with `x32-ABI target process is supported only by x86_64`.  
-*4: tested on github actions on both glibc and musl
+*4: tested on github actions with glibc.  
+*5: tested on github actions with both glibc and musl.  
+
 
 ## Windows
 

--- a/src/linux/elf.c
+++ b/src/linux/elf.c
@@ -221,8 +221,8 @@ static int open_libc(FILE **fp_out, pid_t pid, size_t *addr)
         injector__set_errmsg("failed to open %s. (error: %s)", buf, strerror(errno));
         return INJERR_OTHER;
     }
-    /* /libc.so.6 or /libc-2.{DIGITS}.so */
-    if (regcomp(&reg, "/libc(\\.so\\.6|-2\\.[0-9]+\\.so)", REG_EXTENDED) != 0) {
+    /* /libc.so.6 or /libc-2.{DIGITS}.so or /lib/ld-musl-{arch}.so.1 */
+    if (regcomp(&reg, "/libc(\\.so\\.6|-2\\.[0-9]+\\.so)|/ld-musl-.+?\\.so\\.1", REG_EXTENDED) != 0) {
         injector__set_errmsg("regcomp failed!");
         return INJERR_OTHER;
     }


### PR DESCRIPTION
Hello, thanks for this project, I love it and use it quite often 😄 
It'd be great to add support for musl libc. It's a pretty simple change - we only need to add the the [standard musl shared library path](https://wiki.musl-libc.org/guidelines-for-distributions.html) (under "Standard Pathnames") to the libc regex.

Changes:
- Added support for musl
- Added a CI job to test support for musl
- Changed tests to support musl
- On line 268 I added a call to `waitpid`, as just killing the target processes caused them to linger as zombies
- On line 322 I changed the library name from `Makefile` to `no such library` because the musl error message contains the library's absolute path, so it was simpler to just give it a non-existent path. An added benfit of that change is that it makes the test a bit less confusing in my opinion. When I first saw the error message `unexpected injection error message: dlopen failed: Error loading shared library /__w/injector/injector/tests/Makefile: Exec format error` I thought that there was a bug in the tests causing the injection of a wrong file.