### PR TITLE
Fix wrong error on Mac when process doesn't exist

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ jobs:
         submodules: true
     - name: Install packages
       run: |
+        sudo apt update
         sudo apt install -y gcc-multilib
     - name: run tests
       run: |

--- a/src/macos/injector.c
+++ b/src/macos/injector.c
@@ -34,6 +34,7 @@
 int injector_attach(injector_t **injector_out, pid_t pid)
 {
     injector_t *injector;
+    arch_t self_arch, target_arch;
     int rv = 0;
 
     injector__errmsg_is_set = 0;
@@ -44,9 +45,15 @@ int injector_attach(injector_t **injector_out, pid_t pid)
         return INJERR_NO_MEMORY;
     }
     injector->pid = pid;
-	arch_t self_arch = injector__get_process_arch(getpid());
-	arch_t target_arch = injector__get_process_arch(pid);
-	arch_t sys_arch = injector__get_system_arch(pid);
+	rv = injector__get_process_arch(getpid(), &self_arch);
+	if (rv != 0) {
+	    goto error_exit;
+	}
+	rv = injector__get_process_arch(pid, &target_arch);
+	if (rv != 0) {
+	    goto error_exit;
+	}
+	arch_t sys_arch = injector__get_system_arch();
 
 	if(self_arch != ARCH_UNKNOWN && target_arch != ARCH_UNKNOWN){
 		if(self_arch != target_arch){

--- a/src/macos/injector_internal.h
+++ b/src/macos/injector_internal.h
@@ -118,5 +118,4 @@ extern char injector__errmsg_is_set;
 void injector__set_errmsg(const char *format, ...);
 const char *injector__arch2name(arch_t arch);
 int injector__get_process_arch(pid_t pid, arch_t *arch);
-bool injector__is_translated_process(pid_t pid);
 arch_t injector__get_system_arch();

--- a/src/macos/injector_internal.h
+++ b/src/macos/injector_internal.h
@@ -117,6 +117,6 @@ extern char injector__errmsg[];
 extern char injector__errmsg_is_set;
 void injector__set_errmsg(const char *format, ...);
 const char *injector__arch2name(arch_t arch);
-arch_t injector__get_process_arch(pid_t pid);
+int injector__get_process_arch(pid_t pid, arch_t *arch);
 bool injector__is_translated_process(pid_t pid);
 arch_t injector__get_system_arch();

--- a/src/macos/util.c
+++ b/src/macos/util.c
@@ -136,21 +136,6 @@ arch_t injector__get_system_arch(){
 	}
 	return ARCH_UNKNOWN;
 }
-bool injector__is_translated_process(pid_t pid) {
-	int mib[CTL_MAXNAME] = {0};
-	mib[0] = CTL_KERN;
-	mib[1] = KERN_PROC;
-	mib[2] = KERN_PROC_PID;
-	mib[3] = pid;
-	size_t length = 4;
-	struct kinfo_proc proc_info = {0};	
-	size_t size = sizeof(proc_info);
-		
-	if(sysctl(mib, (u_int)length, &proc_info, &size, NULL, 0) != 0) {
-		return false; 
-	}
-	return P_TRANSLATED == (P_TRANSLATED & proc_info.kp_proc.p_flag);
-}
 const char *injector__arch2name(arch_t arch)
 {
     switch (arch) {


### PR DESCRIPTION
Before this PR, when trying to inject a process that doesn't exist on Mac, the displayed error would be `"i386 target process isn't supported by x86_64 process."`, due to an uncovered edge case.

Now it shows `Process <pid> not found` instead.
